### PR TITLE
Text Commands - Add new "private" level Permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@ config.js
 /jsonFiles/userReturnMessages.json
 
 /textCommands/shutdown.js
-/textCommands/experiments.js
 
 /buttons/shutdown.js

--- a/constants.js
+++ b/constants.js
@@ -18,6 +18,7 @@ module.exports = {
         TEXT_COMMAND_NO_PERMISSION_OWNER: `Sorry, but that Command can only be used by the Owner of this Server!`,
         TEXT_COMMAND_NO_PERMISSION_ADMIN: `Sorry, but that Command can only be used by the Owner of this Server, and those with the \`ADMINISTRATOR\` Permission.`,
         TEXT_COMMAND_NO_PERMISSION_MODERATOR: `Sorry, but that Command can only be used by this Server's Moderators, those with the \`ADMINISTRATOR\` Permission, and this Server's Owner.`,
+        TEXT_COMMAND_NO_PERMISSION_GENERIC: `Sorry, but you do not have the permission to use that Command.`,
         TEXT_COMMAND_ARGUMENTS_REQUIRED: `Sorry, but this Command requires arguments to be included in its usage.\n`,
         TEXT_COMMAND_ARGUMENTS_MINIMUM: `Sorry, but this Command requires a **minimum** of {{minimumArguments}} arguments, while you only included {{givenArguments}} arguments.`,
         TEXT_COMMAND_ARGUMENTS_MAXIMUM: `Sorry, but this Command requires a **maximum** of {{maximumArguments}} arguments, while you only included {{givenArguments}} arguments`,

--- a/modules/textCommandHandler.js
+++ b/modules/textCommandHandler.js
@@ -4,6 +4,7 @@ const Discord = require('discord.js');
 const { client } = require('../constants.js');
 const CONSTANTS = require('../constants.js');
 const { PREFIX, TwilightZebbyID } = require('../config.js');
+const TextCommandAllowLists = require('../hiddenJsonFiles/commandAllowList.json');
 
 module.exports = {
     /**
@@ -87,6 +88,13 @@ module.exports = {
                         if ( message.author.id !== TwilightZebbyID && message.author.id !== message.guild.ownerId && !message.member.permissions.has("ADMINISTRATOR") && !message.member.permissions.has("BAN_MEMBERS") && !message.member.permissions.has("KICK_MEMBERS") && !message.member.permissions.has("MANAGE_CHANNELS") && !message.member.permissions.has("MANAGE_GUILD") && !message.member.permissions.has("MANAGE_MESSAGES") && !message.member.permissions.has("MANAGE_ROLES") && !message.member.permissions.has("MANAGE_THREADS") && !message.member.permissions.has("MODERATE_MEMBERS") )
                         {
                             return await message.reply({ content: CONSTANTS.errorMessages.TEXT_COMMAND_NO_PERMISSION_MODERATOR, allowedMentions: { parse: [], repliedUser: false } });
+                        }
+
+                    case "private":
+                        // Check per-Command per-User Allow List to see if User has been granted permission to use this Command
+                        if ( !TextCommandAllowLists[`${commandName}`]?.includes(message.author.id) )
+                        {
+                            return await message.reply({ content: CONSTANTS.errorMessages.TEXT_COMMAND_NO_PERMISSION_GENERIC, allowedMentions: { parse: [], repliedUser: false } });
                         }
 
                     case "everyone":

--- a/templates/templateTextCommand.js
+++ b/templates/templateTextCommand.js
@@ -44,6 +44,7 @@ module.exports = {
     //    - "owner" for Guild Owners & TwilightZebby
     //    - "admin" for those with the ADMIN Guild Permission, Guild Owners, & TwilightZebby
     //    - "moderator" for those with Moderator-level Guild Permissions, Admins, Guild Owners, & TwilightZebby
+    //    - "private" for those TwilightZebby explicitly grants permission to use on a per-User allowlist basis. This is non-linear as the above permissions do NOT override this
     //    - "everyone" (or commented out) for everyone to use this command
     limitation: "everyone",
 

--- a/textCommands/addgif.js
+++ b/textCommands/addgif.js
@@ -44,6 +44,7 @@ module.exports = {
     //    - "owner" for Guild Owners & TwilightZebby
     //    - "admin" for those with the ADMIN Guild Permission, Guild Owners, & TwilightZebby
     //    - "moderator" for those with Moderator-level Guild Permissions, Admins, Guild Owners, & TwilightZebby
+    //    - "private" for those TwilightZebby explicitly grants permission to use on a per-User allowlist basis. This is non-linear as the above permissions do NOT override this
     //    - "everyone" (or commented out) for everyone to use this command
     limitation: "developer",
 

--- a/textCommands/clearcomp.js
+++ b/textCommands/clearcomp.js
@@ -44,6 +44,7 @@ module.exports = {
     //    - "owner" for Guild Owners & TwilightZebby
     //    - "admin" for those with the ADMIN Guild Permission, Guild Owners, & TwilightZebby
     //    - "moderator" for those with Moderator-level Guild Permissions, Admins, Guild Owners, & TwilightZebby
+    //    - "private" for those TwilightZebby explicitly grants permission to use on a per-User allowlist basis. This is non-linear as the above permissions do NOT override this
     //    - "everyone" (or commented out) for everyone to use this command
     limitation: "developer",
 

--- a/textCommands/register.js
+++ b/textCommands/register.js
@@ -44,6 +44,7 @@ module.exports = {
     //    - "owner" for Guild Owners & TwilightZebby
     //    - "admin" for those with the ADMIN Guild Permission, Guild Owners, & TwilightZebby
     //    - "moderator" for those with Moderator-level Guild Permissions, Admins, Guild Owners, & TwilightZebby
+    //    - "private" for those TwilightZebby explicitly grants permission to use on a per-User allowlist basis. This is non-linear as the above permissions do NOT override this
     //    - "everyone" (or commented out) for everyone to use this command
     limitation: "developer",
 

--- a/textCommands/say.js
+++ b/textCommands/say.js
@@ -45,6 +45,7 @@ module.exports = {
     //    - "owner" for Guild Owners & TwilightZebby
     //    - "admin" for those with the ADMIN Guild Permission, Guild Owners, & TwilightZebby
     //    - "moderator" for those with Moderator-level Guild Permissions, Admins, Guild Owners, & TwilightZebby
+    //    - "private" for those TwilightZebby explicitly grants permission to use on a per-User allowlist basis. This is non-linear as the above permissions do NOT override this
     //    - "everyone" (or commented out) for everyone to use this command
     limitation: "developer",
 

--- a/textCommands/unregister.js
+++ b/textCommands/unregister.js
@@ -44,6 +44,7 @@ module.exports = {
     //    - "owner" for Guild Owners & TwilightZebby
     //    - "admin" for those with the ADMIN Guild Permission, Guild Owners, & TwilightZebby
     //    - "moderator" for those with Moderator-level Guild Permissions, Admins, Guild Owners, & TwilightZebby
+    //    - "private" for those TwilightZebby explicitly grants permission to use on a per-User allowlist basis. This is non-linear as the above permissions do NOT override this
     //    - "everyone" (or commented out) for everyone to use this command
     limitation: "developer",
 


### PR DESCRIPTION
The `private` Permission acts as an allow list of sorts on a per-User basis.
Basically, if your User ID isn't given permission to a Text Command with this Permission Level, you cannot use it.

This Permission is *not* overridden by the `moderator`, `admin`, nor `owner` Permissions, as such, this Permission is non-linear :)