### PR TITLE
Update 5.13.1

### DIFF
--- a/buttons/inforole.js
+++ b/buttons/inforole.js
@@ -27,10 +27,13 @@ module.exports = {
         const targetMemberID = buttonInteraction.customId.slice(9);
         const targetMember = await buttonInteraction.guild.members.fetch(targetMemberID);
         const targetMemberRoles = targetMember.roles.cache.filter(role => role.id !== targetMember.guild.id); // Filter out @everyone
+
+        // Sort Roles by position
+        const sortedMemberRoles = targetMemberRoles.sort((roleA, roleB) => roleB.rawPosition - roleA.rawPosition);
         
         // Role Strings
         let roleStrings = [];
-        targetMemberRoles.forEach(role => roleStrings.push(`<@&${role.id}>`));
+        sortedMemberRoles.forEach(role => roleStrings.push(`<@&${role.id}>`));
 
         // Assemble Role information
         const memberRoleEmbed = new Discord.MessageEmbed().setColor(targetMember.displayHexColor)

--- a/buttons/newroleedit.js
+++ b/buttons/newroleedit.js
@@ -23,7 +23,7 @@ module.exports = {
      */
     async execute(buttonInteraction)
     {
-        let roleCache = client.roleMenu.get("createMenuRoleCache");
+        let roleCache = client.roleMenu.get(`createMenuRoleCache_${buttonInteraction.guildId}`);
 
         // Fetch current details
         let roleID = buttonInteraction.customId.split("_").pop();

--- a/buttons/roleedit.js
+++ b/buttons/roleedit.js
@@ -23,7 +23,7 @@ module.exports = {
      */
     async execute(buttonInteraction)
     {
-        let roleCache = client.roleMenu.get("editRoles");
+        let roleCache = client.roleMenu.get(`editRoles_${buttonInteraction.guildId}`);
 
         // Fetch current details
         let roleID = buttonInteraction.customId.split("_").pop();

--- a/modals/createembeddata.js
+++ b/modals/createembeddata.js
@@ -53,7 +53,7 @@ module.exports = {
         else { delete menuEmbed.color; }
 
         // Update Stored Embed
-        client.roleMenu.set("createEmbed", menuEmbed);
+        client.roleMenu.set(`createEmbed_${modalInteraction.guildId}`, menuEmbed);
 
         // Update Component to "no roles" one, if it was first Embed edit
         if ( modalInteraction.message.components[modalInteraction.message.components.length - 1].components[modalInteraction.message.components[modalInteraction.message.components.length - 1].components.length - 1].options.length === 2 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moobot",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "moobot",
-      "version": "5.13.0",
+      "version": "5.13.1",
       "license": "MIT",
       "dependencies": {
         "bufferutil": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "name": "moobot",
   "description": "A private Discord bot made by TwilightZebby",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/selects/createrolemenu.js
+++ b/selects/createrolemenu.js
@@ -72,7 +72,11 @@ module.exports = {
 
             case "cancel":
                 // Cancels creation of Menu
-                client.roleMenu.clear();
+                client.roleMenu.delete(`originalResponse_${selectInteraction.guildId}`);
+                client.roleMenu.delete(`createEmbed_${selectInteraction.guildId}`);
+                client.roleMenu.delete(`createMenuButtons_${selectInteraction.guildId}`);
+                client.roleMenu.delete(`createMenuRoleCache_${selectInteraction.guildId}`);
+                
                 await selectInteraction.update({ content: `Creation of new Menu has been cancelled. You may now dismiss or delete this message.`, embeds: [], components: [] });
                 break;
 

--- a/selects/editrolemenu.js
+++ b/selects/editrolemenu.js
@@ -72,7 +72,12 @@ module.exports = {
 
             case "cancel":
                 // Cancels Editing of Menu
-                client.roleMenu.clear();
+                client.roleMenu.delete(`originalEditResponse_${selectInteraction.guildId}`);
+                client.roleMenu.delete(`editEmbed_${selectInteraction.guildId}`);
+                client.roleMenu.delete(`editButtons_${selectInteraction.guildId}`);
+                client.roleMenu.delete(`editRoles_${selectInteraction.guildId}`);
+                client.roleMenu.delete(`menuMessageID_${selectInteraction.guildId}`);
+                
                 await selectInteraction.update({ content: `Editing of existing Menu has been cancelled. You may now dismiss or delete this message.`, embeds: [], components: [] });
                 break;
 

--- a/slashCommands/start.js
+++ b/slashCommands/start.js
@@ -15,8 +15,8 @@ const ActivityIDs = new Discord.Collection().set("poker", "755827207812677713")
 .set("bobble", "947957217959759964").set("ask", "976052223358406656");
 
 // Boost Requirements for Activities
-const NoBoostRequirement = [ "youtube", "sketch", "snacks" ];
-const T1BoostRequirement = [ "poker", "chess", "letter", "spell", "checkers", "blazing", "putt", "land", "bobble", "ask" ];
+const NoBoostRequirement = [ "youtube", "sketch", "snacks", "ask" ];
+const T1BoostRequirement = [ "poker", "chess", "letter", "spell", "checkers", "blazing", "putt", "land", "bobble" ];
 const T2BoostRequirement = [  ];
 const T3BoostRequirement = [  ];
 

--- a/slashCommands/start.js
+++ b/slashCommands/start.js
@@ -81,6 +81,7 @@ module.exports = {
                     { name: "YouTube Together", value: "youtube" }, // No Boost Requirement
                     { name: "Sketch Heads", value: "sketch" }, // No Boost Requirement
                     { name: "Word Snacks", value: "snacks" }, // No Boost Requirement
+                    { name: "Ask Away", value: "ask" }, // No Boost Requirement
                     { name: "Poker Night", value: "poker" }, // Boost T1
                     { name: "Chess in the Park", value: "chess" }, // Boost T1
                     { name: "Letter League", value: "letter" }, // Boost T1
@@ -90,7 +91,6 @@ module.exports = {
                     { name: "Putt Party", value: "putt" }, // Boost T1
                     { name: "Land-io", value: "land" }, // Boost T1
                     { name: "Bobble League", value: "bobble" }, // Boost T1
-                    { name: "Ask Away", value: "ask" } // Boost T1
                 ]
             }
         ];


### PR DESCRIPTION
> **Note**
> The change to remove the Server Boost check for the `Ask Away` Voice Activity in `/start` was a ninja-update for v5.13.0, as such was already pushed to the Bot itself :)

# Changes
- Updated the Roles Button in `/info user` to order the displayed Roles by their Role Position

# Bug Fixes
- Role Menu System Embed not saving to cache correctly during creation
- Role Menu System Role Cache not saving to cache correctly during creation/edit process
- Role Menu System "Cancel" option made to be Guild-specific instead of globally wiping cache