### PR TITLE
Add "Swap" Role Menu Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moobot",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "moobot",
-      "version": "5.14.0",
+      "version": "5.15.0",
       "license": "MIT",
       "dependencies": {
         "bufferutil": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "name": "moobot",
   "description": "A private Discord bot made by TwilightZebby",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Expands the Role Menu System to add a second type, `swap`, thus now refers to the original type as `standard`.

**Standard Role Menu Type**
> Same behaviour as before, allows the User to have one or multiple Roles from the Menu at the same time
> 
> Example use-cases: Notification Roles, Pronoun Roles, Game Roles, etc.

**Swap Role Menu Type**
> Restricts the User to only have zero or one Role from the Menu at any one time. Attempting to grab a different Role from the Menu will grant that Role while revoking the previously granted Role.
> 
> Example use-cases: Colour Roles, Region Roles, etc.